### PR TITLE
chore: fix failing update renovate branch

### DIFF
--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   update-renovate-branch:
+    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.actor == 'renovate[bot]'
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: EarthBuild/actions-setup@main
         with:
-          version: v0.8.6
+          version: v0.8.16
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -2,7 +2,7 @@ name: Update Renovate Branch
 
 on:
   pull_request:
-    branches: [main]
+    # branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -28,5 +28,7 @@ jobs:
         run: earthly --ci --output +compile
       - name: Commit changes
         run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add dist && git commit -m "update dist for Renovate" || echo nothing to commit
           git push

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -2,7 +2,7 @@ name: Update Renovate Branch
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,14 +11,13 @@ concurrency:
 jobs:
   update-renovate-branch:
     if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.actor == 'renovate[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       FORCE_COLOR: 1
       EARTHLY_CONVERSION_PARALLELISM: "5"
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       EARTHLY_INSTALL_ID: "earthly-actions-setup-githubactions"
     steps:
-      - uses: earthly/actions/setup-earthly@v1
+      - uses: EarthBuild/actions-setup@main
         with:
           version: v0.8.6
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -10,7 +10,6 @@ concurrency:
 
 jobs:
   update-renovate-branch:
-    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.actor == 'renovate[bot]'
     runs-on: ubuntu-24.04-arm
     env:
       FORCE_COLOR: 1

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   update-renovate-branch:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
     env:
       FORCE_COLOR: 1
       EARTHLY_CONVERSION_PARALLELISM: "5"
@@ -22,5 +24,9 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           ref: ${{ github.head_ref }}
-      - name: Update Branch
-        run: earthly --ci -P --push +update-dist-for-renovate
+      - name: Build
+        run: earthly --ci --output +compile
+      - name: Commit changes
+        run: |
+          git add dist && git commit -m "update dist for Renovate" || echo nothing to commit
+          git push

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -31,5 +31,5 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git add dist && git commit -m "update dist for Renovate" || echo nothing to commit
+          git add dist && git commit -m "update dist for Renovate"
           git push

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -2,7 +2,7 @@ name: Update Renovate Branch
 
 on:
   pull_request:
-    # branches: [main]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -1,8 +1,8 @@
 name: Update Major Version Branch
 
 on:
-    release:
-      types: [released]
+  release:
+    types: [released]
 
 jobs:
   update-major-version-branch:
@@ -10,7 +10,6 @@ jobs:
     env:
       FORCE_COLOR: 1
       EARTHLY_CONVERSION_PARALLELISM: "5"
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       EARTHLY_INSTALL_ID: "earthly-actions-setup-githubactions"
     steps:
       - uses: earthly/actions/setup-earthly@v1

--- a/Earthfile
+++ b/Earthfile
@@ -98,25 +98,25 @@ lint-newline:
         done; \
         exit $code
 
+# update-dist-for-renovate re-compiles the project and commits the new build to the same branch.
 update-dist-for-renovate:
     FROM alpine/git@sha256:af916bb957a0a7106f86b3e4e583b1e1444957518d8e4132d6a37259c912a277
     RUN git config --global user.name "renovate[bot]" && \
         git config --global user.email "renovate[bot]@users.noreply.github.com" && \
         git config --global url."git@github.com:".insteadOf "https://github.com/"
 
-    ARG git_repo="earthly/actions-setup"
+    ARG git_repo="EarthBuild/actions-setup"
     ARG git_url="git@github.com:$git_repo"
     ARG SECRET_PATH=littleredcorvette-id_rsa
     DO --pass-args git+DEEP_CLONE --GIT_URL=$git_url --SECRET_PATH=$SECRET_PATH
 
-    ARG EARTHLY_GIT_BRANCH
-    LET branch=$EARTHLY_GIT_BRANCH
+    ARG --required EARTHLY_GIT_BRANCH
     RUN --mount=type=secret,id=$SECRET_PATH,mode=0400,target=/root/.ssh/id_rsa \
-         git checkout $branch
+         git checkout $EARTHLY_GIT_BRANCH
     COPY --dir +compile/dist .
     RUN git add dist && git commit -m "update dist for Renovate" || echo nothing to commit
     RUN --push --mount=type=secret,id=$SECRET_PATH,mode=0400,target=/root/.ssh/id_rsa \
-         git push origin $branch
+         git push origin $EARTHLY_GIT_BRANCH
 
 merge-release-to-major-branch:
     FROM alpine/git@sha256:af916bb957a0a7106f86b3e4e583b1e1444957518d8e4132d6a37259c912a277

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.8
 PROJECT earthly-technologies/core
 
 ARG EARTHLY_LIB_VERSION=3.0.1
-IMPORT github.com/earthly/lib/utils/git:$EARTHLY_LIB_VERSION AS git
+IMPORT github.com/EarthBuild/lib/utils/git:$EARTHLY_LIB_VERSION AS git
 
 npm-base:
     FROM node:21.7-alpine3.19@sha256:1e13649e44d505d5410164f5b7325e4ff1ae551e87e6e4f17d74f6b9b0affbff
@@ -97,26 +97,6 @@ lint-newline:
             fi; \
         done; \
         exit $code
-
-# update-dist-for-renovate re-compiles the project and commits the new build to the same branch.
-update-dist-for-renovate:
-    FROM alpine/git@sha256:af916bb957a0a7106f86b3e4e583b1e1444957518d8e4132d6a37259c912a277
-    RUN git config --global user.name "renovate[bot]" && \
-        git config --global user.email "renovate[bot]@users.noreply.github.com" && \
-        git config --global url."git@github.com:".insteadOf "https://github.com/"
-
-    ARG git_repo="EarthBuild/actions-setup"
-    ARG git_url="git@github.com:$git_repo"
-    ARG SECRET_PATH=littleredcorvette-id_rsa
-    DO --pass-args git+DEEP_CLONE --GIT_URL=$git_url --SECRET_PATH=$SECRET_PATH
-
-    ARG --required EARTHLY_GIT_BRANCH
-    RUN --mount=type=secret,id=$SECRET_PATH,mode=0400,target=/root/.ssh/id_rsa \
-         git checkout $EARTHLY_GIT_BRANCH
-    COPY --dir +compile/dist .
-    RUN git add dist && git commit -m "update dist for Renovate" || echo nothing to commit
-    RUN --push --mount=type=secret,id=$SECRET_PATH,mode=0400,target=/root/.ssh/id_rsa \
-         git push origin $EARTHLY_GIT_BRANCH
 
 merge-release-to-major-branch:
     FROM alpine/git@sha256:af916bb957a0a7106f86b3e4e583b1e1444957518d8e4132d6a37259c912a277


### PR DESCRIPTION
The target `update-dist-for-renovate` is deleted due to the duplicated behaviour - checking out the source code a second time.

# Solution

Simplify by using the source code checked out by GitHub Actions as the INPUT for the EarthBuild target, build it and push the changes back into the same branch.

Successful build 👉 https://github.com/EarthBuild/actions-setup/actions/runs/17518472597/job/49759109683