### PR TITLE
Point actions-setup to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install a specific version of earthbuild:
 
 ```yaml
 - name: Install earthbuild
-  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786 #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: 0.8.1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install the latest version of earthbuild:
 
 ```yaml
 - name: Install earthbuild
-  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786 #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     name: example earthbuild test
     runs-on: ubuntu-latest
     steps:
-      - uses: EarthBuild/actions-setup@v1
+      - uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 'latest' # or pin to an specific version, e.g. "0.8.1"
@@ -39,7 +39,7 @@ Install the latest version of earthbuild:
 
 ```yaml
 - name: Install earthbuild
-  uses: EarthBuild/actions-setup@v1
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -48,7 +48,7 @@ Install a specific version of earthbuild:
 
 ```yaml
 - name: Install earthbuild
-  uses: EarthBuild/actions-setup@v1
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: 0.8.1
@@ -58,7 +58,7 @@ Install a version that adheres to a semver range
 
 ```yaml
 - name: Install EarthBuild
-  uses: EarthBuild/actions-setup@v1
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: ^0.8.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     name: example earthbuild test
     runs-on: ubuntu-latest
     steps:
-      - uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
+      - uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786 #v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 'latest' # or pin to an specific version, e.g. "0.8.1"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install a version that adheres to a semver range
 
 ```yaml
 - name: Install EarthBuild
-  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786  #v2.0.0
+  uses: EarthBuild/actions-setup@e11e36ffea530484da8a4e5a4bd17d69de480786 #v2.0.0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     version: ^0.8.0


### PR DESCRIPTION
Updated the EarthBuild actions setup version in the README to v2.0.0.

Closes: https://github.com/EarthBuild/actions-setup/issues/263